### PR TITLE
Correctly quote command line arguments

### DIFF
--- a/run-helm.sh
+++ b/run-helm.sh
@@ -2,4 +2,4 @@
 
 source /setup-kubeconfig.sh
 
-exec /usr/bin/helm $*
+exec /usr/bin/helm "$@"


### PR DESCRIPTION
This allows command line arguments with whitespace etc. to be correctly passed to helm.